### PR TITLE
block.timestamp value defaults to 0,Climber challenge will not work properly

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,6 @@
 [default]
 verbosity = 2
+block_timestamp = 1
 
 ## set only when the `hardhat` profile is selected
 [hardhat]


### PR DESCRIPTION
block_timestamp needs to be set in the configuration,if not, **block.timestamp** will default to zero,Climber challenge will not work properly
```solidity
        assertGt(
            ClimberVault(address(climberVaultProxy))
                .getLastWithdrawalTimestamp(),
            0
        );
```
![1](https://user-images.githubusercontent.com/106421396/182578014-3d683c55-0759-4f6a-8aef-f0d37f0e8f4a.png)
.