### PR TITLE
Some suggestions to work with the latest foundry versions

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,8 +1,10 @@
-[default]
+[profile.default]
 verbosity = 2
+fs_permissions = [{ access = "read", path = "./" }]
 
 ## set only when the `hardhat` profile is selected
-[hardhat]
+[profile.hardhat]
 src = "contracts"
 out = "artifacts"
 libs = ["node_modules"]
+fs_permissions = [{ access = "read", path = "./" }]

--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,7 @@ case $1 in
     ;;
 
   puppet | 8 | pupp)
-    forge test --match-contract Puppet
+    forge test --match-contract Puppet --no-match-contract PuppetV2
     ;;
 
   puppet-v2 | 9 | pupp2)

--- a/test/Levels/backdoor/Backdoor.t.sol
+++ b/test/Levels/backdoor/Backdoor.t.sol
@@ -36,6 +36,11 @@ contract Backdoor is Test {
         charlie = users[2];
         david = users[3];
 
+        vm.label(alice, "Alice");
+        vm.label(bob, "Bob");
+        vm.label(charlie, "Charlie");
+        vm.label(david, "David");
+
         attacker = payable(
             address(uint160(uint256(keccak256(abi.encodePacked("attacker")))))
         );

--- a/test/Levels/free-rider/FreeRider.t.sol
+++ b/test/Levels/free-rider/FreeRider.t.sol
@@ -149,7 +149,9 @@ contract FreeRider is Test {
 
     function testExploit() public {
         /** EXPLOIT START **/
+        vm.startPrank(attacker, attacker);
 
+        vm.stopPrank();
         /** EXPLOIT END **/
         validation();
     }


### PR DESCRIPTION
Hey there, 

Thank you for providing such a great repo, I went through this over the last two weeks and enjoyed it a lot. 

I noticed a few issues as I went so I figured I would do a pr to propose a few fixes for them. 

Issues: 
- With the latest foundry you now have to specify access permissions in the config, otherwise it breaks code deployment such as the one in https://github.com/nicolasgarcia214/damn-vulnerable-defi-foundry/blob/c5e4289b62ad4788afba244aaaa0c52fb1d1a185/test/Levels/puppet/Puppet.t.sol#L72. See https://github.com/foundry-rs/foundry/issues/3140 for an entrypoint into the issue.
- Running ./run.sh 8 runs both Puppet and PuppetV2. Added a --no-match-contract in the command to only run the v1. 
- Added default vm.startPrank code in FreeRider with attacker as both arguments otherwise the check in https://github.com/nicolasgarcia214/damn-vulnerable-defi-foundry/blob/c5e4289b62ad4788afba244aaaa0c52fb1d1a185/src/Contracts/free-rider/FreeRiderBuyer.sol#L35 fails.
- Added some labels on addresses in Backdoor

These changes are pretty minor :) 
Thank you for your work 