### PR TITLE
Update FreeRider.t.sol success conditions

### DIFF
--- a/test/Levels/free-rider/FreeRider.t.sol
+++ b/test/Levels/free-rider/FreeRider.t.sol
@@ -151,7 +151,6 @@ contract FreeRider is Test {
 
         // Attacker must have earned all ETH from the payout
         assertGt(attacker.balance, BUYER_PAYOUT);
-        assertEq(address(freeRiderBuyer).balance, 0);
 
         // The buyer extracts all NFTs from its associated contract
         vm.startPrank(buyer);


### PR DESCRIPTION
The balance of `freeRiderBuyer` should be equal to `NFT_PRICE` (15 ether).

Tincho's Damn Vulnerable DeFi doesn't even have this assertion: [Link](https://github.com/tinchoabbate/damn-vulnerable-defi/blob/33120e97e9dbe8c297496a99549e6408a3944e95/test/free-rider/free-rider.challenge.js#L111)

## Describe your changes

Removed assertion to check if `freeRiderBuyer`'s balance is equal to 0.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules